### PR TITLE
The type of an object field is inconsistent.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ const App = (props) => {
     const noteObject = {
       content: newNote,
       important: Math.random() > 0.5,
-      id: String(notes.length + 1),
+      id: notes.length + 1,
     }
 
     setNotes(notes.concat(noteObject))


### PR DESCRIPTION
In the part 2-b (Forms) of the **fullstackopen** course, the _notes_ array in the _main.jsx_ file has an _id_ property for each of the respective objects, which has a JavaScript Number type. But while adding a new note (temporarily) in the _addNote_ event handler function of the _App.jsx_ module, we are typecasting the new value of the newly created _id_ property from the Number type to the String type, which is not needed (and in fact adds a bit of inconsistency among the _id_ properties of all the objects inside the _notes_ array). I've tried to remove the typecasting in this pull request - kindly correct me if I'm wrong.